### PR TITLE
Remove leprechaun shoes override of treasure lists

### DIFF
--- a/Better Train Loot/Better Train Loot/BetterTrainLootMod.cs
+++ b/Better Train Loot/Better Train Loot/BetterTrainLootMod.cs
@@ -64,19 +64,6 @@ namespace BetterTrainLoot
                 string trainCarFile = Path.Combine("DataFiles", "trains.json");
                 trainCars = helper.Data.ReadJsonFile<Dictionary<TRAINS, TrainData>>(trainCarFile) ?? TrainDefaultConfig.CreateTrainCarData(trainCarFile);
 
-                bool updateLoot = false;
-
-                //updated list to include new base game treasure
-                foreach (var train in  trainCars.Values)
-                    if (!train.HasItem("(B)806"))
-                    {
-                        train.treasureList.Add(new TrainTreasure("(B)806", "Leprechaun Shoes", 0.01, LOOT_RARITY.RARE, true));
-                        updateLoot = true;
-                    }
-
-                if (updateLoot)
-                    helper.Data.WriteJsonFile(trainCarFile, trainCars);
-
                 SetupMultiplayerObject();
             }
         }


### PR DESCRIPTION
Leprechaun shoes have been on the default treasure lists for more than a year now (since [the update for 1.5](https://github.com/AairTheGreat/StardewValleyMods/commit/d598e2d4943034387cb56365392376ddca2fc3ed#diff-b1dfebeab4bc822d49ad8e23f209a7409c8968e32a6159e5d2138bafeebb23c8)) and any players installing this should have them without the need for this additional check.

This is also a bit annoying for any player making custom treasure lists who tries to remove the shoes, as they're re-added when the game is launched. (The current solution requires leaving the shoes on each train treasure list, but disabled.)

(PR against the original mod was never merged: https://github.com/AairTheGreat/StardewValleyMods/pull/8)